### PR TITLE
Add main

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     { "name": "Seth Fitzsimmons", "email": "seth@mojodna.net" },
     { "name": "Wade Simmons", "email": "wade@wades.im" },
   ],
+  "main": "build/default/hashlib",
   "directories": { "lib": "./build/default" },
   "engines": { "node": ">= 0.2.0" }
 }


### PR DESCRIPTION
This was all I needed to do to allow npm to install hashlib. You might consider adding this to the default package.json file.
