### PR TITLE
Fix for #25 - Not compiling on Node 0.6 (actually happened since node 0.5.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 2) execute `node-waf configure build`
 
-3) get module from `./build/default/hashlib.node`
+3) get module from `./build/Release/hashlib.node`
 
-You should use `var hashlib = require("./build/default/hashlib");` (way to module)
+You should use `var hashlib = require("./build/Release/hashlib");` (way to module)
 
 ### way 2 (works if node are installed in default path)
 1) go to the directory with hashlib library

--- a/hashlib.cc
+++ b/hashlib.cc
@@ -11,8 +11,7 @@
 #include <stdio.h>
 
 #include <v8.h>
-#include <ev.h>
-#include <eio.h>
+#include <node.h>
 #include <fcntl.h>
 #include <node_buffer.h>
 

--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@ tests:
 	nodejs ./test.js
 
 install:
-	@mkdir -p ~/.node_libraries && cp ./build/default/hashlib.node ~/.node_libraries/hashlib.node
+	@mkdir -p ~/.node_libraries && cp ./build/Release/hashlib.node ~/.node_libraries/hashlib.node
 
 all: build install
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     { "name": "Seth Fitzsimmons", "email": "seth@mojodna.net" },
     { "name": "Wade Simmons", "email": "wade@wades.im" }
   ],
-  "main": "build/default/hashlib",
+  "main": "build/Release/hashlib",
   "directories": { "lib": "./build/default" },
   "engines": { "node": ">= 0.2.0" }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
     { "name": "Wade Simmons", "email": "wade@wades.im" }
   ],
   "main": "build/Release/hashlib",
-  "directories": { "lib": "./build/default" },
-  "engines": { "node": ">= 0.2.0" }
+  "directories": { "lib": "./build/Release" },
+  "engines": { "node": ">= 0.5.5" }
 }

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-var hashlib = require("./build/default/hashlib");
+var hashlib = require("./build/Release/hashlib");
 var sys = require("sys");
 var md5 = require("./test/md5");
 var assert = require("assert");


### PR DESCRIPTION
Fix for issue #25

[hashlib.cc] - Including node.h instead of ev.h and eio.h. node.h includes these files correctly, which might move around from one version of node to the other. (So basically, node.h should be included instead of specifically including ev and eio.)
[README.md, makefile, package.json, test.js] - Changing the '/build/default/hashlib' path to '/build/Release/hashlib'. Node-waf, starting from node 0.5.5 uses the Release environment by default.
