### PR TITLE
fix can't run in node v0.6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     { "name": "Seth Fitzsimmons", "email": "seth@mojodna.net" },
     { "name": "Wade Simmons", "email": "wade@wades.im" }
   ],
-  "main": "build/default/hashlib",
+  "main": "build/Release/hashlib",
   "directories": { "lib": "./build/Release" },
   "engines": { "node": ">= 0.5.5" }
 }

--- a/wscript
+++ b/wscript
@@ -12,6 +12,8 @@ def configure(conf):
   conf.check_tool("node_addon")
   conf.env.append_value('CPPFLAGS', ['-Du_int32_t=uint32_t', '-Du_int16_t=uint16_t'])
   conf.env.append_value('CCFLAGS', ['-O3'])
+  conf.env.set_variant('Release') 
+
 
 def build(bld):
   libhash = bld.new_task_gen("cc", "shlib")


### PR DESCRIPTION
make the complied stuff go to /build/Release in node v0.4.x and 0.6.x.
look for the main in /build/Release/hashlib.
