### PR TITLE
Fix for building on OSX 10.7 Lion

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,9 +1,21 @@
-all: waf install
+all: 
+	waf install
 
 waf:
 	node-waf configure build
 
 install:
+	UNAME := $(shell uname)
+
+	ifeq ($(UNAME), Darwin)
+		VERSION := $(shell sw_vers | grep 'ProductVersion:' | grep -o '[0-9]*\.[0-9]*\.[0-9]*')
+		
+		ifeq($(VERSION), 10.7.3)
+			@sudo ln -sf /usr/local/include/node/node.h /usr/local/include/node/ev.h
+			@CXXFLAGS=-I/usr/local/include/node/uv-private/
+		endif
+	endif
+
 	@mkdir -p ~/.node_modules && cp ./build/Release/hashlib.node ~/.node_modules/hashlib.node
 
 tests:


### PR DESCRIPTION
Temporary fix for the following issue https://github.com/brainfucker/hashlib/issues/29

Users still need to use the fullpath to hashlib to require it.
